### PR TITLE
Add EVM Models Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "evm-models"]
+	path = evm-models
+	url = https://github.com/coherentopensource/evm-models

--- a/README.md
+++ b/README.md
@@ -32,6 +32,32 @@ pip install -r requirements.txt
 4. Follow the deployment steps mentioned in the previous sections of this document to sync the DAGs to a Google Cloud Storage bucket and configure the Airflow instance to use the GCS bucket as its DAG folder.
 5. Monitor the performance of your Airflow DAGs, Snowflake, BigQuery, and DBT tasks using Datadog and the data consistency job.
 
+## Setting up the EVM Models Submodule
+
+This repository includes the `coherentopensource/evm-models` repository as a submodule. To set up the submodule after cloning this repository, run the following commands:
+
+```bash
+git submodule init
+git submodule update
+```
+
+These commands will initialize and update the submodule, pulling the latest contents of the coherentopensource/evm-models repository into the evm-models directory.
+
+To update the submodule to the latest commit in the future, navigate to the submodule directory (evm-models) and run:
+
+```bash
+git checkout main
+git pull
+```
+
+Then, go back to the root directory of your main repository, commit, and push the submodule update:
+
+```bash
+git add evm-models
+git commit -m "Update evm-models submodule to the latest commit"
+git push
+```
+
 ## Contributing 
 
 If you wish to contribute to this project, please follow the standard GitHub workflow:


### PR DESCRIPTION
This pull request adds the coherentopensource/evm-models repository as a Git submodule in the evm-models directory. The purpose of this submodule is to enable seamless integration and versioning of the SQL hosted in the evm-models repository within our Airflow jobs.

Key changes in this PR:

- Adds the coherentopensource/evm-models repository as a submodule in the evm-models directory.
- Updates the .gitmodules file to track the submodule.
- Adds instructions to the README.md file for initializing, updating, and working with the submodule.

By incorporating the evm-models repository as a submodule, we can easily manage and update the SQL scripts and ensure that our Airflow jobs always use the latest and most stable versions. This change streamlines the development process and simplifies collaboration across teams working on different aspects of our data pipeline.