### PR TITLE
Add DAG for Loading Parquet Files into Snowflake Temporary Tables

### DIFF
--- a/dags/decode_dag.py
+++ b/dags/decode_dag.py
@@ -1,7 +1,10 @@
-from datetime import timedelta
 from airflow import DAG
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
-from datetime import datetime
+from airflow.operators.python_operator import BranchPythonOperator
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime, timedelta
+import logging
+import os
 
 # Define default arguments for the DAG
 default_args = {
@@ -11,35 +14,131 @@ default_args = {
     "email_on_retry": False,
     "retries": 1,
     "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
 }
 
 # Instantiate the DAG
 dag = DAG(
     "decode_dag",
     default_args=default_args,
-    description="DAG for decoding data using two SQL scripts",
-    schedule_interval=timedelta(minutes=1),
-    start_date=datetime(2023, 4, 11),
+    description="DAG to load parquet files from GCS to Snowflake and run incremental dbt models",
+    schedule_interval=None,
     catchup=False,
 )
 
-# Task 1: Join raw data with method or event fragments
-join_raw_data = SnowflakeOperator(
-    task_id="join_raw_data",
-    sql="path/to/join_raw_data.sql", # TODO
-    snowflake_conn_id="your_snowflake_connection", # TODO
-    autocommit=True,
+
+def extract_gcs_path(**kwargs):
+    gcs_path = kwargs['dag_run'].conf['name']
+    gcs_path_split = gcs_path.split("/")
+    type = gcs_path_split[0]
+    temp_table_name = gcs_path.replace(".parquet", "").replace("/", "_").replace("-", "_")
+    kwargs["ti"].xcom_push("type", type)
+    kwargs["ti"].xcom_push("gcs_path", gcs_path)
+    kwargs["ti"].xcom_push("temp_table_name", temp_table_name)
+
+    logging.info(f"Extracted gcs_path: {gcs_path}")
+
+extract_gcs_path_task = PythonOperator(
+    task_id="extract_gcs_path",
+    python_callable=extract_gcs_path,
+    provide_context=True,
     dag=dag,
 )
 
-# Task 2: Run decoding DBT job
-run_decoding_dbt_job = SnowflakeOperator(
-    task_id="run_decoding_dbt_job",
-    sql="path/to/run_decoding_dbt_job.sql", # TODO
-    snowflake_conn_id="your_snowflake_connection", # TODO
-    autocommit=True,
+def choose_branch(**kwargs):
+    type = kwargs["ti"].xcom_pull(key="type")
+
+    if type == "traces":
+        return "load_traces_to_temp_table"
+    elif type == "blocks":
+        return "load_blocks_to_temp_table"
+    elif type == "transactions":
+        return "load_transactions_to_temp_table"
+    elif type == "logs":
+        return "load_logs_to_temp_table"
+    else:
+        raise ValueError(f"Unexpected table name: {type}")
+
+branch_task = BranchPythonOperator(
+    task_id="branch_task",
+    python_callable=choose_branch,
+    provide_context=True,
+    dag=dag,
+)
+def log_success(context):
+    logging.info("Successfully loaded parquet file into temp table")
+
+
+def log_failure(context):
+    logging.error("Failed to load parquet file into temp table")
+
+
+load_traces_to_temp_table = SnowflakeOperator(
+    task_id="load_traces_to_temp_table",
+    sql="""
+        CREATE OR REPLACE TEMPORARY TABLE temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }} LIKE ETHEREUM_MANAGED.RAW.TRACES;
+        COPY INTO temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }}
+            FROM @ETHEREUM_MANAGED.RAW.ETH_RAW_STAGE
+            file_format = parquet_format
+            files = ('{{ ti.xcom_pull(key='gcs_path') }}')
+            MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
+    """,
+    snowflake_conn_id="snowflake_temporary_incremental",
+    on_success_callback=log_success,
+    on_failure_callback=log_failure,
     dag=dag,
 )
 
-# Set task dependencies
-join_raw_data >> run_decoding_dbt_job
+load_blocks_to_temp_table = SnowflakeOperator(
+    task_id="load_blocks_to_temp_table",
+    sql="""
+        CREATE OR REPLACE TEMPORARY TABLE temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }} LIKE ETHEREUM_MANAGED.RAW.BLOCKS;
+        COPY INTO temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }}
+            FROM @ETHEREUM_MANAGED.RAW.ETH_RAW_STAGE
+            file_format = parquet_format
+            files = ('{{ ti.xcom_pull(key='gcs_path') }}')
+            MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
+    """,
+    snowflake_conn_id="snowflake_temporary_incremental",
+    on_success_callback=log_success,
+    on_failure_callback=log_failure,
+    dag=dag,
+)
+
+load_transactions_to_temp_table = SnowflakeOperator(
+    task_id="load_transactions_to_temp_table",
+    sql="""
+        CREATE OR REPLACE TEMPORARY TABLE temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }} LIKE ETHEREUM_MANAGED.RAW.TRANSACTIONS;
+        COPY INTO temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }}
+            FROM @ETHEREUM_MANAGED.RAW.ETH_RAW_STAGE
+            file_format = parquet_format
+            files = ('{{ ti.xcom_pull(key='gcs_path') }}')
+            MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
+    """,
+    snowflake_conn_id="snowflake_temporary_incremental",
+    on_success_callback=log_success,
+    on_failure_callback=log_failure,
+    dag=dag,
+)
+
+load_logs_to_temp_table = SnowflakeOperator(
+    task_id="load_logs_to_temp_table",
+    sql="""
+        CREATE OR REPLACE TEMPORARY TABLE temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }} LIKE ETHEREUM_MANAGED.RAW.LOGS;
+        COPY INTO temporary_incremental.{{ ti.xcom_pull(key='temp_table_name') }}
+            FROM @ETHEREUM_MANAGED.RAW.ETH_RAW_STAGE
+            file_format = parquet_format
+            files = ('{{ ti.xcom_pull(key='gcs_path') }}')
+            MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
+    """,
+    snowflake_conn_id="snowflake_temporary_incremental",
+    on_success_callback=log_success,
+    on_failure_callback=log_failure,
+    dag=dag,
+)
+
+extract_gcs_path_task >> branch_task
+branch_task >> load_traces_to_temp_table
+branch_task >> load_blocks_to_temp_table
+branch_task >> load_transactions_to_temp_table
+branch_task >> load_logs_to_temp_table


### PR DESCRIPTION
This PR modifies decode_dag, which is responsible for loading Parquet files from Google Cloud Storage (GCS) into Snowflake temporary tables. The DAG is designed to handle multiple types of data (traces, blocks, transactions, and logs) and load them into their respective temporary tables in Snowflake.

Key features of this DAG:

**Dynamic Branching:** The DAG uses a BranchPythonOperator to determine the type of data (traces, blocks, transactions, or logs) based on the GCS path provided during runtime. This allows the DAG to load data into the appropriate temporary table in Snowflake based on the data type.

**Extract GCS Path Information:** A custom PythonOperator is used to extract the GCS path, data type, and temporary table name from the GCS path provided during runtime. This information is then passed along to the downstream tasks using XComs.

**Snowflake Operators for Data Loading:** Four separate SnowflakeOperator instances are used to load the data into the corresponding temporary tables in Snowflake. These operators handle the creation of the temporary table with the same schema as the source table and perform a COPY INTO operation to load the Parquet data from GCS.

**Error Handling and Logging:** Custom success and failure callbacks are added to the Snowflake operators to log the status of the data loading process.

This DAG lays the groundwork for the next phase of the project, which will involve integrating DBT incremental jobs to process the data in the temporary tables and populate the final destination tables in Snowflake.

Please review the DAG code, provide feedback, and approve the PR if everything looks good. Thank you!