### PR TITLE
[FIX] Submodule Path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "evm-models"]
-	path = evm-models
-	url = https://github.com/coherentopensource/evm-models
+[submodule "dags/evm-models"]
+	path = dags/evm-models
+	url = https://github.com/coherentopensource/evm-models.git


### PR DESCRIPTION
This PR addresses an issue with the submodule path for the coherentopensource/evm-models repository. Previously, the submodule was added with an incorrect local path, causing conflicts and preventing the submodule from being properly initialized.

Changes in this PR include:

- Removed the incorrect submodule reference.
- Re-added the submodule with the correct path in the dags directory.
- Updated the .gitmodules file to reflect the new submodule path.

By fixing the submodule path, we ensure that the coherentopensource/evm-models repository is correctly integrated as a submodule within our project. This allows us to easily maintain and update the submodule as needed, providing access to the latest DAGs and other relevant resources from the evm-models repository.