### PR TITLE
Configure GCP Secrets

### DIFF
--- a/.github/workflows/sync_dags.yml
+++ b/.github/workflows/sync_dags.yml
@@ -32,8 +32,11 @@ jobs:
           git submodule init
           git submodule update
 
+      - name: Set up Google Application Credentials
+        run: echo '${{ secrets.GCP_CREDENTIALS }}' > gcp-credentials.json
+
       - name: Sync DAGs to GCS Bucket
         run: |
           python scripts/sync_dags_to_bucket.py
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+          GOOGLE_APPLICATION_CREDENTIALS: gcp-credentials.json


### PR DESCRIPTION
This PR enhances the security and reliability of our GitHub Actions workflow by securely setting up the GOOGLE_APPLICATION_CREDENTIALS environment variable. Previously, the variable was not properly configured, leading to issues with accessing Google Cloud resources during the execution of the workflow.

Changes in this PR include:

1. Stored the Google Cloud service account JSON key file as a GitHub secret (e.g., GCP_SA_KEY).
2. Added a step in the GitHub Actions workflow to create a temporary JSON file and store the content of the GCP_SA_KEY secret in it.
3. Updated the workflow to set the GOOGLE_APPLICATION_CREDENTIALS environment variable to the path of the temporary JSON file created in the previous step.
4. By securely setting up the GOOGLE_APPLICATION_CREDENTIALS environment variable, we ensure that our GitHub 

 
Actions workflow can successfully access Google Cloud resources while keeping our service account credentials safe and private. This improvement helps maintain the integrity of our CI/CD pipeline and enhances the overall security of our project.