### PR TITLE
Hourly airflow decoding DAGs

### DIFF
--- a/dags/decode_blocks_hourly.py
+++ b/dags/decode_blocks_hourly.py
@@ -1,0 +1,34 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash_operator import BashOperator
+
+# Define default arguments for the DAG
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+}
+
+# Instantiate the DAG
+dag = DAG(
+    "decode_blocks_hourly",
+    default_args=default_args,
+    description="DAG to decode blocks hourly",
+    schedule_interval=timedelta(hours=1),
+    catchup=False,
+)
+
+
+run_incremental_model = BashOperator(
+    task_id='run_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_blocks '
+                 '--target production --vars \"{"raw_database": '
+                 '"ethereum_managed", "contracts_database": "contracts"}\" ',
+    dag=dag
+)
+
+run_incremental_model

--- a/dags/decode_blocks_hourly.py
+++ b/dags/decode_blocks_hourly.py
@@ -23,12 +23,12 @@ dag = DAG(
 )
 
 
-run_incremental_model = BashOperator(
-    task_id='run_dbt_model',
+run_incremental_blocks_dbt_model = BashOperator(
+    task_id='run_incremental_blocks_dbt_model',
     bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_blocks '
                  '--target production --vars \"{"raw_database": '
                  '"ethereum_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_model
+run_incremental_blocks_dbt_model

--- a/dags/decode_logs_hourly.py
+++ b/dags/decode_logs_hourly.py
@@ -1,0 +1,39 @@
+from airflow import DAG
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from airflow.operators.python_operator import BranchPythonOperator
+from airflow.operators.python_operator import PythonOperator
+from datetime import datetime, timedelta
+from airflow.operators.bash_operator import BashOperator
+import logging
+import os
+
+# Define default arguments for the DAG
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+}
+
+# Instantiate the DAG
+dag = DAG(
+    "decode_logs_hourly",
+    default_args=default_args,
+    description="DAG to decode logs hourly",
+    schedule_interval=timedelta(hours=1),
+    catchup=False,
+)
+
+
+run_incremental_model = BashOperator(
+    task_id='run_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_logs '
+                 '--target production --vars \"{"raw_database": '
+                 '"ethereum_managed", "contracts_database": "contracts"}\" ',
+    dag=dag
+)
+
+run_incremental_model

--- a/dags/decode_logs_hourly.py
+++ b/dags/decode_logs_hourly.py
@@ -1,11 +1,6 @@
 from airflow import DAG
-from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
-from airflow.operators.python_operator import BranchPythonOperator
-from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 from airflow.operators.bash_operator import BashOperator
-import logging
-import os
 
 # Define default arguments for the DAG
 default_args = {
@@ -28,12 +23,12 @@ dag = DAG(
 )
 
 
-run_incremental_model = BashOperator(
-    task_id='run_dbt_model',
+run_incremental_logs_dbt_model = BashOperator(
+    task_id='run_incremental_logs_dbt_model',
     bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_logs '
                  '--target production --vars \"{"raw_database": '
                  '"ethereum_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_model
+run_incremental_logs_dbt_model

--- a/dags/decode_traces_hourly.py
+++ b/dags/decode_traces_hourly.py
@@ -18,17 +18,17 @@ dag = DAG(
     "decode_traces_hourly",
     default_args=default_args,
     description="DAG to decode traces hourly",
-    schedule_interval=timedelta(hours=1),
+    schedule_interval=timedelta(hours=2),
     catchup=False,
 )
 
 
-run_incremental_model = BashOperator(
-    task_id='run_dbt_model',
+run_incremental_traces_dbt_model = BashOperator(
+    task_id='run_incremental_traces_dbt_model',
     bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_traces '
                  '--target production --vars \"{"raw_database": '
                  '"ethereum_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_model
+run_incremental_traces_dbt_model

--- a/dags/decode_traces_hourly.py
+++ b/dags/decode_traces_hourly.py
@@ -1,0 +1,34 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash_operator import BashOperator
+
+# Define default arguments for the DAG
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+}
+
+# Instantiate the DAG
+dag = DAG(
+    "decode_traces_hourly",
+    default_args=default_args,
+    description="DAG to decode traces hourly",
+    schedule_interval=timedelta(hours=1),
+    catchup=False,
+)
+
+
+run_incremental_model = BashOperator(
+    task_id='run_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_traces '
+                 '--target production --vars \"{"raw_database": '
+                 '"ethereum_managed", "contracts_database": "contracts"}\" ',
+    dag=dag
+)
+
+run_incremental_model

--- a/dags/decode_transactions_hourly.py
+++ b/dags/decode_transactions_hourly.py
@@ -23,12 +23,12 @@ dag = DAG(
 )
 
 
-run_incremental_model = BashOperator(
-    task_id='run_dbt_model',
+run_incremental_transactions_dbt_model = BashOperator(
+    task_id='run_incremental_transactions_dbt_model',
     bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_transactions '
                  '--target production --vars \"{"raw_database": '
                  '"ethereum_managed", "contracts_database": "contracts"}\" ',
     dag=dag
 )
 
-run_incremental_model
+run_incremental_transactions_dbt_model

--- a/dags/decode_transactions_hourly.py
+++ b/dags/decode_transactions_hourly.py
@@ -1,0 +1,34 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash_operator import BashOperator
+
+# Define default arguments for the DAG
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+}
+
+# Instantiate the DAG
+dag = DAG(
+    "decode_transactions_hourly",
+    default_args=default_args,
+    description="DAG to decode transactions hourly",
+    schedule_interval=timedelta(hours=1),
+    catchup=False,
+)
+
+
+run_incremental_model = BashOperator(
+    task_id='run_dbt_model',
+    bash_command='cd /home/airflow/gcs/dags/evm-models/ && dbt run --models decoded_transactions '
+                 '--target production --vars \"{"raw_database": '
+                 '"ethereum_managed", "contracts_database": "contracts"}\" ',
+    dag=dag
+)
+
+run_incremental_model


### PR DESCRIPTION
This PR introduces 4 new DAGs. Each DAG is responsible for running dbt models for each of our types. They are currently scheduled to run once per hour and for traces, once every two hrs. 