### PR TITLE
add DAGs for creating optimism pipes/tables

### DIFF
--- a/dags/backfill_optimism.py
+++ b/dags/backfill_optimism.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from common import optimism_queries, config
+
+def execute_snowflake_tasks(min, iterations, **kwargs):
+    step = 10000
+    tables = [config.BLOCKS_TABLE_NAME, config.TRANSACTIONS_TABLE_NAME, config.TRACES_TABLE_NAME,
+              config.LOGS_TABLE_NAME]
+    objects = [config.BLOCKS, config.TRANSACTIONS, config.TRACES, config.LOGS]
+    loaders = []
+
+    for y in range(4):
+        for n in range(0, iterations):
+            start = min + (n * step)
+            stop = start + step - 1
+            stmt = optimism_queries.OPTIMISM_COPY_FMT.format(table_name=tables[y], object_type=objects[y], start=start, end=stop)
+            task = SnowflakeOperator(
+                task_id=f"fill_%s_%s_%s" % (n, step, objects[y]),
+                sql=stmt,
+            )
+            loaders.append(task)
+
+    return loaders
+
+SNOWFLAKE_CONN_ID = "snowflake_optimism"
+
+with DAG(
+        "fill-optimism",
+        description="""
+        rebackfill raw optimism data
+    """,
+        doc_md=__doc__,
+        start_date=datetime(2022, 12, 1),
+        schedule=None,
+        schedule_interval=None,
+        default_args={"snowflake_conn_id": SNOWFLAKE_CONN_ID},
+) as dag:
+
+    def wrapper_func(*args, **kwargs):
+        dag_run = kwargs['dag_run']
+        min = dag_run.conf['min']
+        iterations = dag_run.conf['iterations']
+        return execute_snowflake_tasks(min, iterations, **kwargs)
+
+    snowflake_tasks = PythonOperator(
+        task_id="execute_snowflake_tasks",
+        python_callable=wrapper_func,
+        provide_context=True,
+        dag=dag,
+)
+
+begin = EmptyOperator(task_id="begin")
+end = EmptyOperator(task_id="end")
+
+begin >> snowflake_tasks >> end

--- a/dags/common/optimism_queries.py
+++ b/dags/common/optimism_queries.py
@@ -1,0 +1,131 @@
+SQL_CREATE_OPTIMISM_RAW_BLOCKS_TABLE = """
+CREATE OR REPLACE TABLE BLOCKS (
+    difficulty VARCHAR,
+    extra_data VARCHAR,
+    gas_limit VARCHAR,
+    gas_used VARCHAR,
+    block_hash VARCHAR,
+    block_number VARCHAR,
+    logs_bloom VARCHAR,
+    miner VARCHAR,
+    mix_hash VARCHAR,
+    nonce VARCHAR,
+    parent_hash VARCHAR,
+    receipts_root VARCHAR,
+    sha3_uncles VARCHAR,
+    size VARCHAR,
+    state_root VARCHAR,
+    timestamp VARCHAR,
+    total_difficulty VARCHAR,
+    transactions_root VARCHAR,
+    uncles VARCHAR,
+    CONSTRAINT blocks_pkey PRIMARY KEY (block_number) ENFORCED
+);
+"""
+SQL_CREATE_OPTIMISM_RAW_TRANSACTIONS_TABLE = """
+create or replace table TRANSACTIONS (
+    block_hash VARCHAR,
+    block_number VARCHAR,
+    cumulative_gas_used VARCHAR,
+    from_address VARCHAR,
+    gas VARCHAR,
+    gas_price VARCHAR,
+    gas_used VARCHAR,
+    input VARCHAR,
+    logs_bloom VARCHAR,
+    nonce VARCHAR,
+    r VARCHAR,
+    s VARCHAR,
+    status VARCHAR,
+    to_address VARCHAR,
+    transaction_hash VARCHAR,
+    transaction_index VARCHAR,
+    v VARCHAR,
+    value VARCHAR,
+    queue_origin VARCHAR,
+    l1_tx_origin VARCHAR,
+    l1_block_number VARCHAR,
+    l1_timestamp VARCHAR,
+    index VARCHAR,
+    queue_index VARCHAR,
+    raw_transaction VARCHAR,
+    l1_fee VARCHAR,
+    l1_fee_scalar VARCHAR,
+    l1_gas_price VARCHAR,
+    l1_gas_used VARCHAR,
+    constraint transactions_pkey primary key (transaction_hash) enforced
+);
+"""
+SQL_CREATE_OPTIMISM_RAW_TRACES_TABLE = """
+CREATE OR REPLACE TABLE TRACES (
+    block_hash VARCHAR,
+    block_number VARCHAR,
+    error VARCHAR,
+    from_address VARCHAR,
+    gas VARCHAR,
+    gas_used VARCHAR,
+    trace_index VARCHAR,
+    input VARCHAR,
+    output VARCHAR,
+    parent_hash VARCHAR,
+    revert_reason VARCHAR,
+    to_address VARCHAR,
+    trace_hash VARCHAR,
+    transaction_hash VARCHAR,
+    type VARCHAR,
+    value VARCHAR,
+    CONSTRAINT traces_pkey PRIMARY KEY (transaction_hash, trace_hash, parent_hash, trace_index) ENFORCED
+)
+CLUSTER BY (block_number, transaction_hash);
+"""
+SQL_CREATE_OPTIMISM_RAW_LOGS_TABLE = """
+create or replace table LOGS (
+    address VARCHAR,
+    block_hash VARCHAR,
+    block_number VARCHAR,
+    data VARCHAR,
+    log_index VARCHAR,
+    topics VARCHAR,
+    transaction_hash VARCHAR,
+    transaction_index VARCHAR,
+    removed BOOLEAN,
+    constraint logs_pkey primary key (transaction_hash, log_index) enforced
+)
+CLUSTER BY (transaction_hash);
+"""
+
+SQL_CREATE_OPTIMISM_RAW_BLOCKS_PIPE="""
+CREATE or REPLACE PIPE optimism_raw_blocks
+  AUTO_INGEST = true
+  INTEGRATION = optimism_raw_notification
+  AS
+COPY INTO BLOCKS
+FROM @optimism_raw_stage/blocks/ file_format = parquet_format match_by_column_name = case_insensitive pattern = '(.+)\.parquet';
+"""
+
+SQL_CREATE_OPTIMISM_RAW_TRANSACTIONS_PIPE="""
+CREATE or REPLACE PIPE optimism_raw_transactions
+  AUTO_INGEST = true
+  INTEGRATION = optimism_raw_notification
+  AS
+COPY INTO TRANSACTIONS
+FROM @optimism_raw_stage/transactions/ file_format = parquet_format match_by_column_name = case_insensitive pattern = '(.+)\.parquet';
+"""
+
+SQL_CREATE_OPTIMISM_RAW_TRACES_PIPE="""
+CREATE or REPLACE PIPE optimism_raw_traces
+  AUTO_INGEST = true
+  INTEGRATION = optimism_raw_notification
+  AS
+COPY INTO TRACES
+FROM @optimism_raw_stage/traces/ file_format = parquet_format match_by_column_name = case_insensitive pattern = '(.+)\.parquet';
+"""
+
+SQL_CREATE_OPTIMISM_RAW_LOGS_PIPE="""
+CREATE or REPLACE PIPE optimism_raw_logs
+  AUTO_INGEST = true
+  INTEGRATION = optimism_raw_notification
+  AS
+COPY INTO LOGS
+FROM @optimism_raw_stage/logs/ file_format = parquet_format match_by_column_name = case_insensitive pattern = '(.+)\.parquet';
+"""

--- a/dags/common/optimism_queries.py
+++ b/dags/common/optimism_queries.py
@@ -129,3 +129,13 @@ CREATE or REPLACE PIPE optimism_raw_logs
 COPY INTO LOGS
 FROM @optimism_raw_stage/logs/ file_format = parquet_format match_by_column_name = case_insensitive pattern = '(.+)\.parquet';
 """
+
+OPTIMISM_COPY_FMT = """
+COPY INTO
+    {table_name}
+FROM
+	@optimism_raw_stage/{object_type}/blocks_{start}-{end}/
+	    file_format = parquet_format 
+	    match_by_column_name = case_insensitive 
+	    pattern = '^(.+)\.parquet$'
+"""

--- a/dags/create_new_optimism_base_tables.py
+++ b/dags/create_new_optimism_base_tables.py
@@ -1,0 +1,49 @@
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from datetime import datetime
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from common import config, optimism_queries
+
+SNOWFLAKE_CONN_ID="snowflake_ethereum_small"
+MAX_COUNT=100
+
+with DAG(
+        "create-new-optimism-tables",
+        description="""
+        raw optimism tables
+    """,
+        doc_md=__doc__,
+        start_date=datetime(2022, 12, 1),
+        schedule=None,
+        schedule_interval=None,
+        default_args={"snowflake_conn_id": SNOWFLAKE_CONN_ID},
+) as dag:
+    """
+    #### Optimism Block table creation
+    """
+    init_optimism_blocks_table = SnowflakeOperator(
+        task_id="init_optimism_blocks_table",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_BLOCKS_TABLE,
+        params={"table_name": config.BLOCKS_TABLE_NAME},
+    )
+    init_optimism_transactions_table = SnowflakeOperator(
+        task_id="init_optimism_transactions_table",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_TRANSACTIONS_TABLE,
+        params={"table_name": config.TRANSACTIONS_TABLE_NAME},
+    )
+    init_optimism_traces_table = SnowflakeOperator(
+        task_id="init_optimism_traces_table",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_TRACES_TABLE,
+        params={"table_name": config.TRACES_TABLE_NAME},
+    )
+    init_optimism_logs_table = SnowflakeOperator(
+        task_id="init_optimism_logs_table",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_LOGS_TABLE,
+        params={"table_name": config.LOGS_TABLE_NAME},
+    )
+
+
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
+
+    begin >> [init_optimism_blocks_table, init_optimism_transactions_table, init_optimism_traces_table, init_optimism_logs_table] >> end

--- a/dags/create_new_optimism_base_tables.py
+++ b/dags/create_new_optimism_base_tables.py
@@ -4,8 +4,7 @@ from datetime import datetime
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from common import config, optimism_queries
 
-SNOWFLAKE_CONN_ID="snowflake_ethereum_small"
-MAX_COUNT=100
+SNOWFLAKE_CONN_ID="snowflake_optimism_small"
 
 with DAG(
         "create-new-optimism-tables",

--- a/dags/create_optimism_tip_pipes.py
+++ b/dags/create_optimism_tip_pipes.py
@@ -1,0 +1,50 @@
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from datetime import datetime
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from common import config, optimism_queries
+
+SNOWFLAKE_CONN_ID="snowflake_optimism_small"
+
+with DAG(
+        "create-optimism-tip-pipes",
+        description="""
+        raw optimism tip pipes
+    """,
+        doc_md=__doc__,
+        start_date=datetime(2022, 12, 1),
+        schedule=None,
+        schedule_interval=None,
+        default_args={"snowflake_conn_id": SNOWFLAKE_CONN_ID},
+) as dag:
+
+    """
+    #### Optimism pipes creation
+    """
+    init_optimism_blocks_pipe = SnowflakeOperator(
+        task_id="init_optimism_blocks_pipe",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_BLOCKS_PIPE,
+        params={"pipe_name": config.BLOCKS},
+    )
+    init_optimism_transactions_pipe = SnowflakeOperator(
+        task_id="init_optimism_transactions_pipe",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_TRANSACTIONS_PIPE,
+        params={"pipe_name": config.TRANSACTIONS},
+    )
+    init_optimism_traces_pipe = SnowflakeOperator(
+        task_id="init_optimism_traces_pipe",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_TRACES_PIPE,
+        params={"pipe_name": config.TRACES},
+    )
+    init_optimism_logs_pipe = SnowflakeOperator(
+        task_id="init_optimism_logs_pipe",
+        sql=optimism_queries.SQL_CREATE_OPTIMISM_RAW_LOGS_PIPE,
+        params={"pipe_name": config.LOGS},
+    )
+
+
+
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
+
+    begin >> [init_optimism_blocks_pipe, init_optimism_transactions_pipe, init_optimism_traces_pipe, init_optimism_logs_pipe] >> end


### PR DESCRIPTION
This PR introduces two new Airflow DAGs that automate the creation of base Optimism tables and Snowflake pipes to load data into these tables. The purpose of these DAGs is to streamline the process of setting up our data infrastructure for ingesting Optimism transaction data and maintaining the tables with near-real-time updates.