### PR TITLE
Separate optimism backfilling jobs 

### DIFF
--- a/dags/backfill_optimism.py
+++ b/dags/backfill_optimism.py
@@ -1,58 +1,61 @@
-from datetime import datetime
 from airflow import DAG
+from airflow.models.baseoperator import chain
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python_operator import PythonOperator
+from datetime import datetime, timedelta
 from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
 from common import optimism_queries, config
 
-def execute_snowflake_tasks(min, iterations, **kwargs):
-    step = 10000
-    tables = [config.BLOCKS_TABLE_NAME, config.TRANSACTIONS_TABLE_NAME, config.TRACES_TABLE_NAME,
-              config.LOGS_TABLE_NAME]
-    objects = [config.BLOCKS, config.TRANSACTIONS, config.TRACES, config.LOGS]
-    loaders = []
+SNOWFLAKE_CONN_ID="snowflake_optimism"
 
-    for y in range(4):
-        for n in range(0, iterations):
-            start = min + (n * step)
-            stop = start + step - 1
-            stmt = optimism_queries.OPTIMISM_COPY_FMT.format(table_name=tables[y], object_type=objects[y], start=start, end=stop)
-            task = SnowflakeOperator(
-                task_id=f"fill_%s_%s_%s" % (n, step, objects[y]),
-                sql=stmt,
-            )
-            loaders.append(task)
-
-    return loaders
-
-SNOWFLAKE_CONN_ID = "snowflake_optimism"
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+    "snowflake_conn_id": SNOWFLAKE_CONN_ID
+}
 
 with DAG(
-        "fill-optimism",
+        "fill-optimism-v2",
         description="""
-        rebackfill raw optimism data
+        rebackfill raw optimism
     """,
         doc_md=__doc__,
         start_date=datetime(2022, 12, 1),
         schedule=None,
         schedule_interval=None,
-        default_args={"snowflake_conn_id": SNOWFLAKE_CONN_ID},
+        default_args=default_args,
 ) as dag:
+    """
+    #### Optimism Block table creation
+    """
+    min = 0
+    step = 10000
+    iterations = 9000
+    block_loaders = []
+    tx_loaders = []
+    trace_loaders = []
+    log_loaders = []
+    tables = [config.BLOCKS_TABLE_NAME, config.TRANSACTIONS_TABLE_NAME, config.TRACES_TABLE_NAME, config.LOGS_TABLE_NAME]
+    objects = [config.BLOCKS, config.TRANSACTIONS, config.TRACES, config.LOGS]
+    loaders = [block_loaders, tx_loaders, trace_loaders, log_loaders]
 
-    def wrapper_func(*args, **kwargs):
-        dag_run = kwargs['dag_run']
-        min = dag_run.conf['min']
-        iterations = dag_run.conf['iterations']
-        return execute_snowflake_tasks(min, iterations, **kwargs)
+    for y in range(4):
+        for n in range(0,iterations):
+            start = min + (n * step)
+            stop = start + step - 1
+            stmt = optimism_queries.OPTIMISM_COPY_FMT.format(table_name=tables[y], object_type=objects[y], start=start, end=stop)
+            task = SnowflakeOperator(
+                task_id=f"fill_%s_%s_%s" % (start, stop, objects[y]),
+                sql=stmt,
+            )
+            loaders[y].append(task)
 
-    snowflake_tasks = PythonOperator(
-        task_id="execute_snowflake_tasks",
-        python_callable=wrapper_func,
-        provide_context=True,
-        dag=dag,
-)
 
-begin = EmptyOperator(task_id="begin")
-end = EmptyOperator(task_id="end")
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
 
-begin >> snowflake_tasks >> end
+    begin >> block_loaders + tx_loaders + trace_loaders + log_loaders >> end

--- a/dags/backfill_optimism/fill_optimism_logs.py
+++ b/dags/backfill_optimism/fill_optimism_logs.py
@@ -1,0 +1,63 @@
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from datetime import datetime, timedelta
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from common import optimism_queries, config
+
+SNOWFLAKE_CONN_ID="snowflake_optimism"
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+    "snowflake_conn_id": SNOWFLAKE_CONN_ID
+}
+
+with DAG(
+        "fill-optimism-logs-v1",
+        description="""
+        rebackfill raw optimism logs
+    """,
+        doc_md=__doc__,
+        start_date=datetime(2022, 12, 1),
+        schedule=None,
+        schedule_interval=None,
+        default_args=default_args,
+) as dag:
+    """
+    #### backfill optimism logs to 90,000,000 block
+    """
+    min = 0
+    step = 10000
+    iterations = 9000
+    log_loaders = []
+    tables = config.LOGS_TABLE_NAME
+    objects = config.LOGS
+
+    for batch in range(0, 5):
+        current_batch = []
+
+        for n in range(0, 1800):
+            start = min + (n * step)
+            stop = start + step - 1
+            stmt = optimism_queries.OPTIMISM_COPY_FMT.format(table_name=tables, object_type=objects, start=start,
+                                                             end=stop)
+            task = SnowflakeOperator(
+                task_id=f"fill_%s_%s_%s" % (start, stop, objects),
+                sql=stmt,
+            )
+            current_batch.append(task)
+        log_loaders.append(current_batch)
+        min += 1800 * step
+
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
+
+    begin >> log_loaders[0]
+    for i in range(len(log_loaders) - 1):
+        log_loaders[i][-1] >> log_loaders[i + 1]
+    log_loaders[-1][-1] >> end

--- a/dags/backfill_optimism/fill_optimism_traces.py
+++ b/dags/backfill_optimism/fill_optimism_traces.py
@@ -1,0 +1,64 @@
+from airflow import DAG
+from airflow.models.baseoperator import chain
+from airflow.operators.empty import EmptyOperator
+from datetime import datetime, timedelta
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from common import optimism_queries, config
+
+SNOWFLAKE_CONN_ID="snowflake_optimism"
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+    "snowflake_conn_id": SNOWFLAKE_CONN_ID
+}
+
+with DAG(
+        "fill-optimism-traces-v1",
+        description="""
+        rebackfill raw optimism
+    """,
+        doc_md=__doc__,
+        start_date=datetime(2022, 12, 1),
+        schedule=None,
+        schedule_interval=None,
+        default_args=default_args,
+) as dag:
+    """
+    #### backfill optimism traces to block 90,000,000
+    """
+    min = 0
+    step = 10000
+    iterations = 9000
+    trace_loaders = []
+    tables = config.TRACES_TABLE_NAME
+    objects = config.TRACES
+
+    for batch in range(0, 5):
+        current_batch = []
+
+        for n in range(0, 1800):
+            start = min + (n * step)
+            stop = start + step - 1
+            stmt = optimism_queries.OPTIMISM_COPY_FMT.format(table_name=tables, object_type=objects, start=start,
+                                                             end=stop)
+            task = SnowflakeOperator(
+                task_id=f"fill_%s_%s_%s" % (start, stop, objects),
+                sql=stmt,
+            )
+            current_batch.append(task)
+        trace_loaders.append(current_batch)
+        min += 1800 * step
+
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
+
+    begin >> trace_loaders[0]
+    for i in range(len(trace_loaders) - 1):
+        trace_loaders[i][-1] >> trace_loaders[i + 1]
+    trace_loaders[-1][-1] >> end

--- a/dags/backfill_optimism/fill_optimism_transactions.py
+++ b/dags/backfill_optimism/fill_optimism_transactions.py
@@ -1,0 +1,66 @@
+from airflow import DAG
+from airflow.models.baseoperator import chain
+from airflow.operators.empty import EmptyOperator
+from datetime import datetime, timedelta
+from airflow.providers.snowflake.operators.snowflake import SnowflakeOperator
+from common import optimism_queries, config
+
+SNOWFLAKE_CONN_ID="snowflake_optimism"
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime.now() - timedelta(days=1),
+    "snowflake_conn_id": SNOWFLAKE_CONN_ID
+}
+
+with DAG(
+        "fill-optimism-transactions-v1",
+        description="""
+        rebackfill raw optimism
+    """,
+        doc_md=__doc__,
+        start_date=datetime(2022, 12, 1),
+        schedule=None,
+        schedule_interval=None,
+        default_args=default_args,
+) as dag:
+    """
+    #### backfill optimism transactions to 90,000,000 block
+    """
+    min = 0
+    step = 10000
+    iterations = 9000
+    tx_loaders = []
+    tables = config.TRANSACTIONS_TABLE_NAME
+    objects = config.TRANSACTIONS
+
+    for batch in range(0, 5):
+        current_batch = []
+
+        for n in range(0, 1800):
+            start = min + (n * step)
+            stop = start + step - 1
+            stmt = optimism_queries.OPTIMISM_COPY_FMT.format(table_name=tables, object_type=objects, start=start,
+                                                             end=stop)
+            task = SnowflakeOperator(
+                task_id=f"fill_%s_%s_%s" % (start, stop, objects),
+                sql=stmt,
+            )
+            current_batch.append(task)
+        tx_loaders.append(current_batch)
+        min += 1800 * step
+
+
+
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
+
+    begin >> tx_loaders[0]
+    for i in range(len(tx_loaders) - 1):
+        tx_loaders[i][-1] >> tx_loaders[i + 1]
+    tx_loaders[-1][-1] >> end


### PR DESCRIPTION
This PR refactors the optimism backfilling airflow job. Airflow was having issues scheduling all of the tasks for blocks, traces, transactions, and logs. This PR separates the job into 4 separate jobs, one for each type to backfill optimism